### PR TITLE
modernize build.sbt

### DIFF
--- a/hardware/chisel/build.sbt
+++ b/hardware/chisel/build.sbt
@@ -23,60 +23,22 @@ name := "vta"
 version := "0.1.0-SNAPSHOT"
 organization := "edu.washington.cs"
 
-def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // If we're building with Scala > 2.11, enable the compile option
-    //  switch to support our anonymous Bundle definitions:
-    //  https://github.com/scala/bug/issues/10047
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-      case _ => Seq(
-        "-Xsource:2.11",
-        "-language:reflectiveCalls",
-        "-language:implicitConversions",
-        "-deprecation",
-        "-Xlint",
-        "-Ywarn-unused",
-      )
-    }
-  }
-}
-
-def javacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // Scala 2.12 requires Java 8. We continue to generate
-    //  Java 7 compatible code for Scala 2.11
-    //  for compatibility with old clients.
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
-        Seq("-source", "1.7", "-target", "1.7")
-      case _ =>
-        Seq("-source", "1.8", "-target", "1.8")
-    }
-  }
-}
-
 scalaVersion := "2.12.13"
-
-resolvers ++= Seq(
-  Resolver.sonatypeRepo("snapshots"),
-  Resolver.sonatypeRepo("releases"))
-
-val defaultVersions = Map(
-  "chisel3" -> "3.4.2",
-  "chisel-iotesters" -> "1.5.2"
-  )
-
-libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {
-  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }
-
-libraryDependencies ++= Seq(
-"com.fasterxml.jackson.core" % "jackson-databind" % "2.10.3",
-"com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.3"
+scalacOptions ++= Seq(
+  "-Xsource:2.11",
+  "-language:reflectiveCalls",
+  "-deprecation",
+  "-feature",
+  "-Xcheckinit",
 )
 
-scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
-javacOptions ++= javacOptionsVersion(scalaVersion.value)
+resolvers += Resolver.sonatypeRepo("snapshots")
+libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.4.3"
+libraryDependencies += "edu.berkeley.cs" %% "chisel-iotesters" % "1.5.3"
 
-resolvers += Resolver.sonatypeRepo("releases")
+// Intel added an XML library
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.3"
+libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.3"
+
+addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.4.3" cross CrossVersion.full)
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)


### PR DESCRIPTION
This brings the build.sbt more in line with our chisel template: https://github.com/freechipsproject/chisel-template
It also adds the new chisel compiler plugin for (hopefully) better names in the generated Verilog.